### PR TITLE
Fix Teams API

### DIFF
--- a/server/Models/Teams/Teams.py
+++ b/server/Models/Teams/Teams.py
@@ -10,7 +10,7 @@ class TeamsModel:
         self.name = name
         self.owner = None
         self.members = []
-        self.eventID = None
+        self.event_id = None
         self.last_submission_timestamp = None
         self.created_timestamp = None
     
@@ -27,8 +27,8 @@ class TeamsModel:
     def get_members(self) -> List[str]:
         return self.members
     
-    def join_event(self, eventID: str) -> None:
-        self.eventID = eventID
+    def join_event(self, event_id: str) -> None:
+        self.event_id = event_id
 
     def set_last_submission_timestamp(self, time) -> None:
         self.last_submission_timestamp = time
@@ -40,7 +40,7 @@ class TeamsModel:
         return {'name': self.name,
                 'owner': self.owner,
                 'members': self.members,
-                'eventID': self.eventID,
+                'event_id': self.event_id,
                 'last_submission_timestamp': self.last_submission_timestamp,
                 'created_timestamp': self.created_timestamp
                 }

--- a/server/Routes/Teams/Teams.py
+++ b/server/Routes/Teams/Teams.py
@@ -18,6 +18,8 @@ class TeamsRoute(Resource):
         user = None
         with UserManager(User_auth.current_user()) as usermanager:
             user = usermanager.user
+        TeamsRoute.parser.add_argument('event_id', type=str, required=True,
+                            help='This field cannot be left blank')
         TeamsRoute.parser.add_argument('members', type=str, action="append")
         data = TeamsRoute.parser.parse_args()
         with TeamsManager(data['name']) as teamsmanager:
@@ -46,7 +48,7 @@ class TeamsRoute(Resource):
         with UserManager(User_auth.current_user()) as usermanager:
             user = usermanager.user
         TeamsRoute.parser.add_argument('members', type=str, action="append")
-        TeamsRoute.parser.add_argument('eventID', type=str)
+        TeamsRoute.parser.add_argument('event_id', type=str)
         TeamsRoute.parser.add_argument('last_submission_timestamp', type=time)
         data = TeamsRoute.parser.parse_args()
         with TeamsManager(data['name']) as teamsmanager:

--- a/tests/test_teams.py
+++ b/tests/test_teams.py
@@ -48,7 +48,6 @@ def test_register_email(request, receive_email):
         output = filter_link(body)
         test.run(request.node.name, output)
 
-
 # Sends the get request to the link received in the email.
 # Simulates a user opening their email and clicking the very link.
 def test_verify_link(request):
@@ -96,7 +95,7 @@ def test_update_team(request, flaskaddr):
         token = test.get_var('JWT_TOKEN_USER').rstrip()
         test.save_var('JWT_TOKEN_USER', token)
         r = requests.put(f'http://{flaskaddr}/api/teams',
-                            json={'name': 'test_team', 'eventID': "1234"},
+                            json={'name': 'test_team', 'event_id': "1234"},
                             headers={'Authorization': f'Bearer {token}'})
         test.run(request.node.name, f'{r.text}HTTP_Status: {r.status_code}')
 


### PR DESCRIPTION
- Update field eventID to event_id in teams database
- Update logic for checking redundant members/owners: An user who already owns/joins a team will not be able to create/added to another team
- Update POST API: Now request body required name, event_id as a team will be created under specific event