### PR TITLE
enable upload file to consumer

### DIFF
--- a/server/Managers/Matches/MatchRequestManager.py
+++ b/server/Managers/Matches/MatchRequestManager.py
@@ -56,6 +56,7 @@ class MatchRequestManager:
     def delete_request(self, id) -> bool:
         return self.db.delete_one({'_id': ObjectId(id)})
 
-    def commit(self) -> None:
-        self.db.insert_one({'event_id': self.request.event_id, 'teams': self.request.teams,
+    def commit(self):
+        res = self.db.insert_one({'event_id': self.request.event_id, 'teams': self.request.teams,
                            'created_timestamp': self.request.created_timestamp})
+        self._id = res.inserted_id

--- a/server/Managers/Matches/MatchRequestManager.py
+++ b/server/Managers/Matches/MatchRequestManager.py
@@ -57,6 +57,5 @@ class MatchRequestManager:
         return self.db.delete_one({'_id': ObjectId(id)})
 
     def commit(self):
-        res = self.db.insert_one({'event_id': self.request.event_id, 'teams': self.request.teams,
+        self.db.insert_one({'event_id': self.request.event_id, 'teams': self.request.teams,
                            'created_timestamp': self.request.created_timestamp})
-        self._id = res.inserted_id

--- a/server/Managers/Matches/MatchResultManager.py
+++ b/server/Managers/Matches/MatchResultManager.py
@@ -1,7 +1,7 @@
 from datetime import datetime
-from typing import List, Optional
 
 from bson import ObjectId
+from dotenv.main import set_key
 
 from server.Database import Mongo
 from server.Models.Matches.Matches import MatchResultModel
@@ -28,7 +28,6 @@ class MatchResultManager:
 
     def create_match(self, data) -> bool:
         try:
-            self._id = data['match_id']
             self.pass_data(data)
             self.match.set_created_timestamp(str(datetime.utcnow()))
             self.commit()
@@ -46,4 +45,5 @@ class MatchResultManager:
         return None
 
     def commit(self) -> None:
-        self.db.insert_one({'_id': ObjectId(self.get_id()), 'event_id': self.match.event_id, 'winner_id': self.match.winner_id, 'loser_id': self.match.loser_id, 'created_timestamp': self.match.created_timestamp})
+        res = self.db.insert_one({'event_id': self.match.event_id, 'winner_id': self.match.winner_id, 'loser_id': self.match.loser_id, 'created_timestamp': self.match.created_timestamp})
+        self._id = res.inserted_id

--- a/server/Managers/Matches/MatchResultManager.py
+++ b/server/Managers/Matches/MatchResultManager.py
@@ -28,6 +28,7 @@ class MatchResultManager:
 
     def create_match(self, data) -> bool:
         try:
+            self._id = data['match_id']
             self.pass_data(data)
             self.match.set_created_timestamp(str(datetime.utcnow()))
             self.commit()
@@ -45,4 +46,4 @@ class MatchResultManager:
         return None
 
     def commit(self) -> None:
-        self.db.insert_one({'event_id': self.match.event_id, 'winner_id': self.match.winner_id, 'loser_id': self.match.loser_id, 'created_timestamp': self.match.created_timestamp})
+        self.db.insert_one({'_id': ObjectId(self.get_id()), 'event_id': self.match.event_id, 'winner_id': self.match.winner_id, 'loser_id': self.match.loser_id, 'created_timestamp': self.match.created_timestamp})

--- a/server/Routes/Consumer/Consumer.py
+++ b/server/Routes/Consumer/Consumer.py
@@ -3,11 +3,11 @@ from http import HTTPStatus
 from flask import make_response, request, abort, jsonify
 from bson.json_util import dumps, ObjectId
 from flask_restful import Resource, reqparse
+from server.Managers.Blob.BlobStorage import BlobStorageModel
 
 from server.Managers.Matches.MatchRequestManager import MatchRequestManager
 from server.Managers.Events.AdminEvents import EventsManager
 from server.Managers.Teams.TeamsManager import TeamsManager
-from server.Managers.Auth.UserManager import User_auth
 from server.config import Configuration
 
 
@@ -20,21 +20,30 @@ class ConsumerRoute(Resource):
         if data['token'] != Configuration.CONSUMER_TOKEN:
             return abort(HTTPStatus.UNAUTHORIZED)
 
-    @User_auth.login_required
     def post(self):
         parser = reqparse.RequestParser()
         parser.add_argument('team1_id', type=str, required=True)
         parser.add_argument('team2_id', type=str, required=True)
         parser.add_argument('name', type=str, required=True)
         data = parser.parse_args()
+        match_file = request.files['file']
+        if not match_file.filename.endswith('.zip'):
+            return make_response(jsonify({'message': 'File must be a zip file'}), 400)
         with EventsManager(data['name']) as eventmanager:
             eventdata = eventmanager.find_event()
             data['event_id'] = eventdata['_id']
+            blob_storage = BlobStorageModel()
+            container = blob_storage.get_container(str(eventdata['_id']))
+            if not container:
+                container = blob_storage.create_container(
+                    str(eventdata['_id']))
             with TeamsManager() as teamsmanager:
                 challenging_team = teamsmanager.find_team_by_id(ObjectId(data['team1_id']))
                 if challenging_team['last_challenge_timestamp'] == None:
                     with MatchRequestManager() as requestmanager:
                         if requestmanager.create_request(data):
+                            name = f'match_{requestmanager.get_id()}'
+                            container.upload_blob(name, match_file)
                             challenging_team['last_challenge_timestamp'] = str(datetime.utcnow())
                             teamsmanager.commit_data(challenging_team)
                             return make_response(jsonify({'message': 'Successfully created a match request'}), HTTPStatus.OK)

--- a/server/Routes/Consumer/Consumer.py
+++ b/server/Routes/Consumer/Consumer.py
@@ -1,9 +1,9 @@
 from datetime import datetime
 from http import HTTPStatus
-from flask import make_response, request, abort, jsonify
+from flask import make_response, abort, jsonify
 from bson.json_util import dumps, ObjectId
 from flask_restful import Resource, reqparse
-from server.Managers.Blob.BlobStorage import BlobStorageModel
+from server.Managers.Auth.UserManager import User_auth
 
 from server.Managers.Matches.MatchRequestManager import MatchRequestManager
 from server.Managers.Events.AdminEvents import EventsManager
@@ -20,30 +20,21 @@ class ConsumerRoute(Resource):
         if data['token'] != Configuration.CONSUMER_TOKEN:
             return abort(HTTPStatus.UNAUTHORIZED)
 
+    @User_auth.login_required
     def post(self):
         parser = reqparse.RequestParser()
         parser.add_argument('team1_id', type=str, required=True)
         parser.add_argument('team2_id', type=str, required=True)
         parser.add_argument('name', type=str, required=True)
         data = parser.parse_args()
-        match_file = request.files['file']
-        if not match_file.filename.endswith('.zip'):
-            return make_response(jsonify({'message': 'File must be a zip file'}), 400)
         with EventsManager(data['name']) as eventmanager:
             eventdata = eventmanager.find_event()
             data['event_id'] = eventdata['_id']
-            blob_storage = BlobStorageModel()
-            container = blob_storage.get_container(str(eventdata['_id']))
-            if not container:
-                container = blob_storage.create_container(
-                    str(eventdata['_id']))
             with TeamsManager() as teamsmanager:
                 challenging_team = teamsmanager.find_team_by_id(ObjectId(data['team1_id']))
                 if challenging_team['last_challenge_timestamp'] == None:
                     with MatchRequestManager() as requestmanager:
                         if requestmanager.create_request(data):
-                            name = f'match_{requestmanager.get_id()}'
-                            container.upload_blob(name, match_file)
                             challenging_team['last_challenge_timestamp'] = str(datetime.utcnow())
                             teamsmanager.commit_data(challenging_team)
                             return make_response(jsonify({'message': 'Successfully created a match request'}), HTTPStatus.OK)

--- a/server/Routes/Match/Match.py
+++ b/server/Routes/Match/Match.py
@@ -13,6 +13,7 @@ class MatchRoute(Resource):
         parser = reqparse.RequestParser()
         parser.add_argument('token', type=str, required=True,
                             help='Must provide secret token to use this api')
+        parser.add_argument('match_id', type=str, required=True)
         parser.add_argument('event_id', type=str, required=True)
         parser.add_argument('winner_id', type=str, required=True)
         parser.add_argument('loser_id', type=str, required=True)

--- a/server/Routes/Match/Match.py
+++ b/server/Routes/Match/Match.py
@@ -1,6 +1,7 @@
 from http import HTTPStatus
 from flask import make_response, request, abort, jsonify
 from flask_restful import Resource, reqparse
+from server.Managers.Blob.BlobStorage import BlobStorageModel
 from server.Managers.Leaderboard.LeaderboardManager import LeaderboardManager
 
 from server.Managers.Matches.MatchResultManager import MatchResultManager
@@ -13,18 +14,26 @@ class MatchRoute(Resource):
         parser = reqparse.RequestParser()
         parser.add_argument('token', type=str, required=True,
                             help='Must provide secret token to use this api')
-        parser.add_argument('match_id', type=str, required=True)
         parser.add_argument('event_id', type=str, required=True)
         parser.add_argument('winner_id', type=str, required=True)
         parser.add_argument('loser_id', type=str, required=True)
         data = parser.parse_args()
+        match_file = request.files['file']
+        if not match_file.filename.endswith('.zip'):
+            return make_response(jsonify({'message': 'File must be a zip file'}), 400)
         if data['token'] != Configuration.CONSUMER_TOKEN:
             return abort(HTTPStatus.UNAUTHORIZED)
         with MatchResultManager() as matchmanager:
             if matchmanager.create_match(data):
-                with LeaderboardManager() as leaderboardmanager:
-                    all_team_ids = leaderboardmanager.get_leaderboard(data['event_id'])
-                    leaderboardmanager.update_leaderboard(all_team_ids, data)
+                # with LeaderboardManager() as leaderboardmanager:
+                #     all_team_ids = leaderboardmanager.get_leaderboard(data['event_id'])
+                #     leaderboardmanager.update_leaderboard(all_team_ids, data)
+                blob_storage = BlobStorageModel()
+                container = blob_storage.get_container(data['event_id'])
+                if not container:
+                    container = blob_storage.create_container(data['event_id'])
+                name = f'match_{matchmanager.get_id()}'
+                container.upload_blob(name, match_file)
                 return make_response(jsonify({'message': 'Successfully created a match record'}), HTTPStatus.OK)
             else:
                 raise SystemError("Error occurs when create match record")


### PR DESCRIPTION
- Consumer can upload zip file with `file` in the body. The request id created by consumer will be referred as `match_id`
- The zip file will be stored under `event_id` container, with the name `match_<match_id>`
- Now to create a match record, consumer need to provide `match_id`, which is the request id created from above